### PR TITLE
feat: replace formatWithSpaces with a locale based number format

### DIFF
--- a/src/components/common/ProgressMilestones.tsx
+++ b/src/components/common/ProgressMilestones.tsx
@@ -1,4 +1,4 @@
-import { formatWithSpaces } from '@utils/generic';
+import { localeFormat } from '@utils/generic';
 import React from 'react';
 import { CheckSquare } from 'react-feather';
 
@@ -27,9 +27,9 @@ export default function ProgressMilestones({title, maxValue, currentValue, miles
         <div className="absolute top-0 left-0 right-0 bottom-0 h-5 z-[5] max-w-full" style={{backgroundColor: 'var(--primary-color)', width: `${overallPercent}%`}}/>
 
         <div className="absolute top-[1-px] left-0 z-10 text-sm px-2 flex justify-between w-full">
-          <span>{formatWithSpaces(currentValue)} / {formatWithSpaces(maxValue)}</span>
+          <span>{localeFormat(currentValue)} / {localeFormat(maxValue)}</span>
 
-          <span>({formatWithSpaces(overallPercent)}%)</span>
+          <span>({localeFormat(overallPercent)}%)</span>
         </div>
 
         {milestones.map((milestone) => (

--- a/src/components/compare/charts/RiddenKilled.tsx
+++ b/src/components/compare/charts/RiddenKilled.tsx
@@ -4,7 +4,7 @@ import { ChartData, ChartOptions } from 'chart.js';
 import { useRecoilValue } from 'recoil';
 import { Trans, useTranslation } from 'react-i18next';
 import {
-  formatWithSpaces,
+  localeFormat,
   getSumFromArrayOfIntegers,
   nFormatter
 } from '@utils/generic';
@@ -72,22 +72,22 @@ export default function RiddenKilled() {
       <p className="mt-3 text-sm">
         <Trans
           i18nKey="graphs.labels.commons_killed"
-          values={{count: formatWithSpaces(overallCommonsKilled)}}
+          values={{count: localeFormat(overallCommonsKilled)}}
           components={{b: <b/>}}
         /> |&nbsp;
         <Trans
           i18nKey="graphs.labels.mutations_killed"
-          values={{count: formatWithSpaces(overallMutationsKilled)}}
+          values={{count: localeFormat(overallMutationsKilled)}}
           components={{b: <b/>}}
         /> |&nbsp;
         <Trans
           i18nKey="graphs.labels.sleepers_killed"
-          values={{count: formatWithSpaces(overallSleepersKilled)}}
+          values={{count: localeFormat(overallSleepersKilled)}}
           components={{b: <b/>}}
         /> |&nbsp;
         <Trans
           i18nKey="graphs.labels.total_ridden_killed"
-          values={{count: formatWithSpaces(overallRiddenKilled)}}
+          values={{count: localeFormat(overallRiddenKilled)}}
           components={{b: <b/>}}
         />
       </p>

--- a/src/components/self/Miscellaneous.tsx
+++ b/src/components/self/Miscellaneous.tsx
@@ -1,7 +1,7 @@
 import { Table, useMantineTheme } from '@mantine/core';
 import { useRecoilValue } from 'recoil';
 import { useTranslation } from 'react-i18next';
-import { formatWithSpaces, getFormattedDate } from '@utils/generic';
+import { localeFormat, getFormattedDate } from '@utils/generic';
 import StatisticsState from '@components/self/StatisticsState';
 import { MiscellaneousStatistics } from '@components/statistics/types';
 import { createRef } from 'react';
@@ -16,92 +16,92 @@ export default function Miscellaneous() {
   const stats = [
     {
       statistic: t('miscellaneous.statistics.items_purchased_caravan'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.CaravanItemsPurchased]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.CaravanItemsPurchased]),
       avg: null,
     },
     {
       statistic: t('miscellaneous.statistics.ammo_dropped'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.AmmoDropped]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.AmmoDropped]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.AmmoDropped]),
     },
     {
       statistic: t('miscellaneous.statistics.cards_played'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.CardsPlayed]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.CardsPlayed]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.CardsPlayed]),
     },
     {
       statistic: t('miscellaneous.statistics.cleaners_rescued'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRescued]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRescued]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRescued]),
     },
     {
       statistic: t('miscellaneous.statistics.cleaners_revived'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRevived]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRevived]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.CleanersRevived]),
     },
     {
       statistic: t('miscellaneous.statistics.friendly_cleaners_killed'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyCleanersKilled]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyCleanersKilled]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyCleanersKilled]),
     },
     {
       statistic: t('miscellaneous.statistics.friendly_damage_inflicted'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyDamageInflicted]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyDamageInflicted]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.FriendlyDamageInflicted]),
     },
     {
       statistic: t('miscellaneous.statistics.healing_other'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedOther]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedOther]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedOther]),
     },
     {
       statistic: t('miscellaneous.statistics.healing_self'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedSelf]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedSelf]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.HealingAppliedSelf]),
     },
     {
       statistic: t('miscellaneous.statistics.damage_commons'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.CommonRiddenDamageInflicted]),
-      avg: formatWithSpaces(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.CommonRiddenDamageInflicted], false) as number),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.CommonRiddenDamageInflicted]),
+      avg: localeFormat(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.CommonRiddenDamageInflicted], false) as number),
     },
     {
       statistic: t('miscellaneous.statistics.damage_mutations'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.SpecialRiddenDamageInflicted]),
-      avg: formatWithSpaces(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.SpecialRiddenDamageInflicted], false) as number),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.SpecialRiddenDamageInflicted]),
+      avg: localeFormat(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.SpecialRiddenDamageInflicted], false) as number),
     },
     {
       statistic: t('miscellaneous.statistics.damage_ridden_overall'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.EnemyDamageInflicted]),
-      avg: formatWithSpaces(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.EnemyDamageInflicted], false) as number),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.EnemyDamageInflicted]),
+      avg: localeFormat(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.EnemyDamageInflicted], false) as number),
     },
     {
       statistic: t('miscellaneous.statistics.damage_weakspot'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.WeakSpotDamageInflicted]),
-      avg: formatWithSpaces(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.WeakSpotDamageInflicted], false) as number),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.WeakSpotDamageInflicted]),
+      avg: localeFormat(statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.WeakSpotDamageInflicted], false) as number),
     },
     {
       statistic: t('miscellaneous.statistics.times_died_as_cleaner'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesDiedAsCleaner]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesDiedAsCleaner]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesDiedAsCleaner]),
     },
     {
       statistic: t('miscellaneous.statistics.times_incapped_as_cleaner'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesIncappedAsCleaner]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesIncappedAsCleaner]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.TimesIncappedAsCleaner]),
     },
     {
       statistic: t('miscellaneous.statistics.treasures_doors_opened'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.TreasureDoorsOpened]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.TreasureDoorsOpened]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.TreasureDoorsOpened]),
     },
     {
       statistic: t('miscellaneous.statistics.hordes_triggered'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.HordesTriggered]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.HordesTriggered]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.HordesTriggered]),
     },
     {
       statistic: t('miscellaneous.statistics.snitchers_silenced'),
-      value: formatWithSpaces(statistics.miscellaneousStatistics[MiscellaneousStatistics.SnitchersSilenced]),
+      value: localeFormat(statistics.miscellaneousStatistics[MiscellaneousStatistics.SnitchersSilenced]),
       avg: statistics.getAverageValuePerMissionCompleted(statistics.miscellaneousStatistics[MiscellaneousStatistics.SnitchersSilenced]),
     },
   ];

--- a/src/components/self/charts/MissionsCompletedPerCleaner.tsx
+++ b/src/components/self/charts/MissionsCompletedPerCleaner.tsx
@@ -3,7 +3,7 @@ import { Chart } from 'react-chartjs-2';
 import { useRecoilValue } from 'recoil';
 import { Trans, useTranslation } from 'react-i18next';
 import { ChartData, ChartOptions } from 'chart.js';
-import { formatWithSpaces, nFormatter } from '@utils/generic';
+import { localeFormat, nFormatter } from '@utils/generic';
 import StatisticsState from '@components/self/StatisticsState';
 import { DifficultyColors } from '@utils/colors';
 import { Cleaners, Difficulties } from '@components/statistics/types';
@@ -125,7 +125,7 @@ export default function MissionsCompletedPerCleaner() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.total_missions_completed"
-            values={{count: formatWithSpaces(statistics.missionsStatistics.missionsCompleted)}}
+            values={{count: localeFormat(statistics.missionsStatistics.missionsCompleted)}}
             components={{b: <b/>}}
           />
         </Badge>

--- a/src/components/self/charts/RiddenKilled.tsx
+++ b/src/components/self/charts/RiddenKilled.tsx
@@ -4,7 +4,7 @@ import { ChartData, ChartOptions } from 'chart.js';
 import { useRecoilValue } from 'recoil';
 import { Trans, useTranslation } from 'react-i18next';
 import {
-  formatWithSpaces,
+  localeFormat,
   getSuggestedMaxFromArrayOfIntegers,
   getSumFromArrayOfIntegers,
   nFormatter
@@ -57,7 +57,7 @@ export default function RiddenKilled() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.commons_killed"
-            values={{count: formatWithSpaces(statistics.riddenKilled.riddenCommonKilled)}}
+            values={{count: localeFormat(statistics.riddenKilled.riddenCommonKilled)}}
             components={{b: <b/>}}
           /> (APM: {statistics.getAverageValuePerMissionCompleted(statistics.riddenKilled.riddenCommonKilled)})
         </Badge>
@@ -65,7 +65,7 @@ export default function RiddenKilled() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.mutations_killed"
-            values={{count: formatWithSpaces(statistics.riddenKilled.riddenMutationsKilled)}}
+            values={{count: localeFormat(statistics.riddenKilled.riddenMutationsKilled)}}
             components={{b: <b/>}}
           /> (APM: {statistics.getAverageValuePerMissionCompleted(statistics.riddenKilled.riddenMutationsKilled)})
         </Badge>
@@ -73,7 +73,7 @@ export default function RiddenKilled() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.sleepers_killed"
-            values={{count: formatWithSpaces(statistics.riddenKilled.riddenSleeperKilled)}}
+            values={{count: localeFormat(statistics.riddenKilled.riddenSleeperKilled)}}
             components={{b: <b/>}}
           /> (APM: {statistics.getAverageValuePerMissionCompleted(statistics.riddenKilled.riddenSleeperKilled)})
         </Badge>
@@ -81,7 +81,7 @@ export default function RiddenKilled() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.total_ridden_killed"
-            values={{count: formatWithSpaces(statistics.riddenKilled.riddenKilledTotal)}}
+            values={{count: localeFormat(statistics.riddenKilled.riddenKilledTotal)}}
             components={{b: <b/>}}
           /> (APM: {statistics.getAverageValuePerMissionCompleted(statistics.riddenKilled.riddenKilledTotal)})
         </Badge>

--- a/src/components/self/charts/RiddenKilledPerWeaponTypeSet.tsx
+++ b/src/components/self/charts/RiddenKilledPerWeaponTypeSet.tsx
@@ -1,7 +1,7 @@
 import 'chart.js/auto';
 import { Chart } from 'react-chartjs-2';
 import { useRecoilValue } from 'recoil';
-import { formatWithSpaces, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
+import { localeFormat, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
 import { Trans, useTranslation } from 'react-i18next';
 import { ChartData, ChartOptions } from 'chart.js';
 import StatisticsState from '@components/self/StatisticsState';
@@ -83,7 +83,7 @@ export default function RiddenKilledPerWeaponTypeSet({title, type}: Props) {
           <Badge>
             <Trans
               i18nKey="graphs.labels.ridden_killed_fist"
-              values={{count: formatWithSpaces(statistics.weaponsKills[Weapons.Fist])}}
+              values={{count: localeFormat(statistics.weaponsKills[Weapons.Fist])}}
               components={{b: <b/>}}
             />
           </Badge>
@@ -93,7 +93,7 @@ export default function RiddenKilledPerWeaponTypeSet({title, type}: Props) {
           <Badge>
             <Trans
               i18nKey="graphs.labels.ridden_killed_bob_arm"
-              values={{count: formatWithSpaces(statistics.weaponsKills[Weapons.BobArm])}}
+              values={{count: localeFormat(statistics.weaponsKills[Weapons.BobArm])}}
               components={{b: <b/>}}
             />
           </Badge>
@@ -104,7 +104,7 @@ export default function RiddenKilledPerWeaponTypeSet({title, type}: Props) {
         <Badge>
           <Trans
             i18nKey="graphs.labels.total_ridden_killed"
-            values={{count: formatWithSpaces(total)}}
+            values={{count: localeFormat(total)}}
             components={{b: <b/>}}
           />
         </Badge>

--- a/src/components/self/charts/SwarmGamesPlayed.tsx
+++ b/src/components/self/charts/SwarmGamesPlayed.tsx
@@ -1,7 +1,7 @@
 import 'chart.js/auto';
 import { Chart } from 'react-chartjs-2';
 import { useRecoilValue } from 'recoil';
-import { formatWithSpaces, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
+import { localeFormat, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
 import { Trans, useTranslation } from 'react-i18next';
 import { ChartData, ChartOptions } from 'chart.js';
 import StatisticsState from '@components/self/StatisticsState';
@@ -48,7 +48,7 @@ export default function SwarmGamesPlayed() {
         <Badge>
           <Trans
             i18nKey="graphs.labels.total_games_played"
-            values={{count: formatWithSpaces(statistics.pvpStatistics.gamesPlayed)}}
+            values={{count: localeFormat(statistics.pvpStatistics.gamesPlayed)}}
             components={{b: <b/>}}
           />
         </Badge>

--- a/src/components/self/charts/SwarmKills.tsx
+++ b/src/components/self/charts/SwarmKills.tsx
@@ -1,7 +1,7 @@
 import 'chart.js/auto';
 import { Chart } from 'react-chartjs-2';
 import { useRecoilValue } from 'recoil';
-import { formatWithSpaces, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
+import { localeFormat, getSuggestedMaxFromArrayOfIntegers, nFormatter } from '@utils/generic';
 import { Trans, useTranslation } from 'react-i18next';
 import { ChartData, ChartOptions } from 'chart.js';
 import StatisticsState from '@components/self/StatisticsState';
@@ -48,7 +48,7 @@ export default function SwarmKills() {
         <Badge mt={3}>
           <Trans
             i18nKey="graphs.labels.total_kills"
-            values={{count: formatWithSpaces(statistics.pvpStatistics.killsAsCleaner + statistics.pvpStatistics.killsAsRidden)}}
+            values={{count: localeFormat(statistics.pvpStatistics.killsAsCleaner + statistics.pvpStatistics.killsAsRidden)}}
             components={{b: <b/>}}
           />
         </Badge>

--- a/src/translations/helpers.ts
+++ b/src/translations/helpers.ts
@@ -1,10 +1,10 @@
-import { formatWithSpaces } from '@utils/generic';
+import { localeFormat } from '@utils/generic';
 import { Weapons, WeaponTypes } from '@components/statistics/types';
 
 export function translateKillsTooltip(t: Function, count: number, percent: number)
 {
   return t('graphs.labels.x_kills', {
-    count: formatWithSpaces(count),
+    count: localeFormat(count),
     percent: percent,
   });
 }
@@ -12,7 +12,7 @@ export function translateKillsTooltip(t: Function, count: number, percent: numbe
 export function translateMissionsTooltip(t: Function, count: number, percent: number)
 {
   return t('graphs.labels.x_missions', {
-    count: formatWithSpaces(count),
+    count: localeFormat(count),
     percent: percent,
   });
 }

--- a/src/utils/charts.ts
+++ b/src/utils/charts.ts
@@ -1,5 +1,5 @@
 import { ChartType, TooltipItem } from 'chart.js';
-import { formatWithSpaces } from '@utils/generic';
+import { localeFormat } from '@utils/generic';
 import { translateKillsTooltip, translateMissionsTooltip } from '@translations/helpers';
 import { Weapons } from '@components/statistics/types';
 
@@ -7,7 +7,7 @@ export function tooltipCallbackLabelPlain(context: TooltipItem<ChartType>, overa
   const value = context.raw as number;
   const percent = Math.round(value / overallValue * 100);
 
-  return `${formatWithSpaces(value)} (${percent}%)`;
+  return `${localeFormat(value)} (${percent}%)`;
 }
 
 export function tooltipCallbackLabelKills(context: TooltipItem<ChartType>, overallValue: number, t: Function): string {

--- a/src/utils/generic.ts
+++ b/src/utils/generic.ts
@@ -1,3 +1,4 @@
+import i18n from '@translations/i18n';
 import { Cleaners } from '@components/statistics/types';
 
 export function getCleanerNameById(cleanerId: string)
@@ -7,9 +8,9 @@ export function getCleanerNameById(cleanerId: string)
   return Object.keys(Cleaners)[index];
 }
 
-export function formatWithSpaces(x: number)
+export function localeFormat(x: number)
 {
-  return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+  return x.toLocaleString(i18n.language)
 }
 
 export function nFormatter(num: number, digits: number = 0)


### PR DESCRIPTION
Applies language selection to number format localization.

en-GB, zh-TW, jp-JP and kr-KR = "999,999.99"
fr-FR = "999 999,99"
de-DE, es-eS and nl-NL = "999.999,99"
ru-RU "999 999,99" (wider space than fr-FR)